### PR TITLE
Customizable hard power off timeout

### DIFF
--- a/TinyCircuits-TinyTVs-Firmware.ino
+++ b/TinyCircuits-TinyTVs-Firmware.ino
@@ -239,8 +239,8 @@ void loop() {
 
   if (TVscreenOffMode) {
 #ifndef TinyTVKit
-    // Turn TV off after 2 minutes in screen off mode
-    if (millis() - TVscreenOffModeStartTime > 1000 * 60 * 2) {
+    // Turn TV off after specified duration in screen off mode
+    if (millis() - TVscreenOffModeStartTime > 1000 * powerTimeoutSecs) {
       hardwarePowerOff();
     }
 #endif

--- a/settings.h
+++ b/settings.h
@@ -18,11 +18,26 @@ bool liveMode = true;
 bool doStaticEffects = true;
 bool showChannelNumber = true;
 bool showVolumeBar = true;
+int powerTimeoutSecs = 2 * 60;
 
 //#define cdc SerialUSB
 bool timeStamp = false;
 
-const char keyNames[][15] = {"tvType", "fwVersion", "channel", "volume", "alphabetize", "loopVideo", "liveVideo", "static", "showChannel", "showVolume"}; //showTime?
+const char keyNames[][15] = {
+  "tvType",
+  "fwVersion",
+  "channel",
+  "volume",
+  "alphabetize",
+  "loopVideo",
+  "liveVideo",
+  "static",
+  "showChannel",
+  "showVolume",
+#ifndef TinyTVKit
+  "powerOffSecs",
+#endif
+}; //showTime?
 
 String getKeyValue(String key) {
   if (key == String("tvType")) return String(TYPE_STRING);
@@ -39,6 +54,7 @@ String getKeyValue(String key) {
   if (key == String("static")) return String(doStaticEffects ? "true" : "false");
   if (key == String("showChannel")) return String(showChannelNumber ? "true" : "false");
   if (key == String("showVolume")) return String(showVolumeBar ? "true" : "false");
+  if (key == String("powerOffSecs")) return String(powerTimeoutSecs);
   return "none";
 }
 
@@ -74,6 +90,7 @@ bool setValueByKey(String key, String val) {
   else if (key == String("static")) doStaticEffects = (val == (String)"true") ? true : false;
   else if (key == String("showChannel")) showChannelNumber = (val == (String)"true") ? true : false;
   else if (key == String("showVolume")) showVolumeBar = (val == (String)"true") ? true : false;
+  else if (key == String("powerOffSecs")) powerTimeoutSecs = max(3,val.toInt());
   else return false;
   return true;
 }


### PR DESCRIPTION
This is similar to my previous pull request, but:
- branched off of a much more recent commit
- none of the version numbers or firmware builds now that those requirements have changed
- now it enforces a 3-second minimum, if you try to set it lower.

I've tested, and on the first launch with no value set, it correctly uses (and writes) the default of 120 seconds (which matches current behaviour), until you change it to something else in the settings file.

I'm assuming it's desireable for powerOffSecs to not appear in the settings file of hardware that can't use the feature, but if you'd rather the settings be consistent even to the inclusion of unused settings, I can remove those directives wrapping the value inside of keyNames.

FWIW, I've only tested this personally on a TinyTV2.