### PR TITLE
Settings to resume or shuffle on boot

### DIFF
--- a/SD_AVI.ino
+++ b/SD_AVI.ino
@@ -17,6 +17,14 @@ uint8_t nextChunkTag[8];
 bool videoStreamReady = false;
 uint64_t tsMillisInitial = 0;
 uint32_t currentAudioRate = 0;
+uint64_t millisOffset = 0;
+
+void setMillisOffset(uint64_t val){
+  millisOffset = val;
+}
+uint64_t getMillisOffset(){
+  return millisOffset;
+}
 
 uint32_t getInt(uint8_t * intOffset) {
   return (uint32_t(intOffset[3]) << 24) | (uint32_t(intOffset[2]) << 16) | (uint32_t(intOffset[1]) << 8) | (uint32_t(intOffset[0]));
@@ -272,7 +280,7 @@ int startVideoByChannel(int channelNum) {
 
   channelNumber = newVideoIndex;
 
-  if (startVideo(aviList[newVideoIndex], liveMode ? millis() / 1000 : 0)) {
+  if (startVideo(aviList[newVideoIndex], liveMode ? (millis()+millisOffset) / 1000 : 0)) {
     return 1;
   }
   return 0;
@@ -288,7 +296,7 @@ int prevVideo() {
 
   channelNumber = currentVideo;
 
-  if (startVideo(aviList[currentVideo], liveMode ? millis() / 1000 : 0)) {
+  if (startVideo(aviList[currentVideo], liveMode ? (millis()+millisOffset) / 1000 : 0)) {
     return 1;
   }
   return 0;
@@ -305,7 +313,7 @@ int nextVideo() {
 
   channelNumber = currentVideo;
 
-  if (startVideo(aviList[currentVideo], liveMode ? millis() / 1000 : 0)) {
+  if (startVideo(aviList[currentVideo], liveMode ? (millis()+millisOffset) / 1000 : 0)) {
     return 1;
   }
   return 0;

--- a/settings.h
+++ b/settings.h
@@ -69,7 +69,7 @@ String getKeyValue(String key) {
 
 void saveSettings() {
   File32 settingsFile;
-  settingsFile.open("settings.txt", O_WRITE | O_CREAT);
+  settingsFile.open("settings.txt", O_WRITE | O_CREAT | O_TRUNC);
   for (int i = 0; i < sizeof(keyNames) / sizeof(keyNames[0]); i++) {
     settingsFile.println(String(keyNames[i]) + "=" + getKeyValue(keyNames[i]));
   }

--- a/settings.h
+++ b/settings.h
@@ -19,6 +19,9 @@ bool doStaticEffects = true;
 bool showChannelNumber = true;
 bool showVolumeBar = true;
 int powerTimeoutSecs = 2 * 60;
+long startTimeSecs = 0;
+bool allowResume = false;
+bool shuffleResume = false;
 
 //#define cdc SerialUSB
 bool timeStamp = false;
@@ -37,6 +40,9 @@ const char keyNames[][15] = {
 #ifndef TinyTVKit
   "powerOffSecs",
 #endif
+  "startTimeSecs",
+  "allowResume",
+  "shuffleResume",
 }; //showTime?
 
 String getKeyValue(String key) {
@@ -55,6 +61,9 @@ String getKeyValue(String key) {
   if (key == String("showChannel")) return String(showChannelNumber ? "true" : "false");
   if (key == String("showVolume")) return String(showVolumeBar ? "true" : "false");
   if (key == String("powerOffSecs")) return String(powerTimeoutSecs);
+  if (key == String("startTimeSecs")) return String(startTimeSecs);
+  if (key == String("allowResume")) return String(allowResume ? "true" : "false");
+  if (key == String("shuffleResume")) return String(shuffleResume ? "true" : "false");
   return "none";
 }
 
@@ -91,6 +100,9 @@ bool setValueByKey(String key, String val) {
   else if (key == String("showChannel")) showChannelNumber = (val == (String)"true") ? true : false;
   else if (key == String("showVolume")) showVolumeBar = (val == (String)"true") ? true : false;
   else if (key == String("powerOffSecs")) powerTimeoutSecs = max(3,val.toInt());
+  else if (key == String("startTimeSecs")) startTimeSecs = val.toInt();
+  else if (key == String("allowResume")) allowResume = (val == (String)"true") ? true : false;
+  else if (key == String("shuffleResume")) shuffleResume = (val == (String)"true") ? true : false;
   else return false;
   return true;
 }


### PR DESCRIPTION
Two new settings.

If "allowResume" is false, it behaves as previous; every video's playback time starts counting from power-on time.

If "allowResume" is true and "shuffleResume" is false, it writes the current seconds value on power-off and reads the stored value on power-on, so it will come back to (basically) the same place it turned off at.

The arduino string-to-int parsing library seems to want everything to be a 32-bit signed int, if I'm understanding correctly -- but that's still decades of time in seconds, so whatever.  (An overflow appears to just make it start at zero, which is fine for an application where the resume function is just for fun, nothing important depends on it...)

If "allowResume" and "shuffleResume" are both true, the system writes the current millis() value to disk, to be used as a random seed on next boot.

I'm honestly not *entirely* certain how well I'm avoiding noticeable bias in my use of the random functions, but in a dozen or so tests of a video of an hour-long countdown timer, it looks pretty random to me.  I'd welcome any improvements to that portion, though.

The one thing that makes me a little nervous: saving the progress (or the milliseconds seed) based on the moment where the power button was pressed, required making the settingsNeedSaved check shorter in that case, or else the power would be off before it could be performed (I believe this is the case even with a longer hard power timeout time, because the logic that checks for whether a save needs to be flushed, doesn't run after the soft power off regardless?  Though I only half-understand that whole process, actually.)  I had originally made the "write settings on power-off requested" timeout instant, but actually, this caused a noticeable hitch in the static animation, so now it waits long enough for that animation to finish (1 second), which now seems to be fine.   Still, this whole approach does feel SLIGHTLY flimsy;  it might be better for the system to ALWAYS write the settings to disk once the animation is over (rather than waiting on a timer that HAPPENS to last the same length of time), and refuse to hard power down until that writing is complete (rather than enforcing two more seconds in the minimum hard-power-off timeout value in the settings file, which appears to be enough time in my experience, but remains a race condition that's making assumptions about disk speed).   I'm going to propose this as-is for now though, as it seems to work, and a proper overhaul might be better made by someone more comfortable with the project.