### PR TITLE
Flush unsaved changes to disk when about to power off

### DIFF
--- a/TinyCircuits-TinyTVs-Firmware.ino
+++ b/TinyCircuits-TinyTVs-Firmware.ino
@@ -244,6 +244,7 @@ void loop() {
   }
 
   if (powerDownTimer && millis() - powerDownTimer > staticTimeMS) {
+    if (settingsNeedSaved) saveSettings();
     //off
     powerDownTimer = 0;
     TVscreenOffMode = true;


### PR DESCRIPTION
If you ever powered off within two seconds of changing the channel, the channel change wouldn't be saved.  This should address that.

I'm no expert, and I'm always extra flinchy around stuff related to saving data and cutting power, but the scenario that this change causes is essentially equivalent to if the settingsNeedSaved timeout had just happened to go off right before the user pushed the power button anyway; the only thing this changes is that sometimes a save will happen *sooner after the setting changed* than it would have, which I assume was only being avoided to prevent redundant writes, and there's no further writes coming after this one so that's not an issue here.    (As a reminder, the minimum value for powerTimeoutSecs is 3 seconds, so at least 3 seconds will pass between this save going off and power being cut, just like before.)