### PR TITLE
Fix/new

### DIFF
--- a/SD_AVI.ino
+++ b/SD_AVI.ino
@@ -465,7 +465,14 @@ void seekTimeMP4(int seekMs) {
   infile.read(tfraElemBuf, tfraElemSize);
   int tfraTime = timescaleDuration = getLongLE(tfraElemBuf);
   int moofOffset = getLongLE(tfraElemBuf+8);
-  seekMs %= (tfraTime * sampleDefaultDuration / MP4Timescale);
+  uint32_t totalMediaTimeMs = (tfraTime * sampleDefaultDuration / MP4Timescale);
+  unsigned int timeOffset = seekMs % totalMediaTimeMs;
+  if((totalMediaTimeMs-timeOffset) < (15*1000)) {
+    infile.seekSet(p0);
+    seekTimeMP4(0); // Loop if less than 15s of video remaining
+    return;
+  }
+  seekMs %= totalMediaTimeMs;
   while(l < r) {
     int m = l + (r-l)/2;
     infile.seekSet(r0 + tfraElemSize*m);
@@ -1086,6 +1093,8 @@ int getVideoInfo(int startTimeOffsetS) {
   uint32_t aviMoviListFrameCount[5];
   aviRIFFSize = 0;
 
+  int p0 = infile.position();
+
   setAVIScreenBuffer();
   #ifndef TinyTVKit
   if(videoBuf[1] == NULL && DOUBLE_BUFFER) {
@@ -1175,6 +1184,11 @@ int getVideoInfo(int startTimeOffsetS) {
         }
         frameRate = getIntBE(chunkData + 20);
         totalFrames = getIntBE(chunkData + 28);
+        unsigned int timeOffset = (startTimeOffsetS * frameRate) % totalFrames;
+        if((totalFrames / frameRate - timeOffset) < 15) {
+          infile.seekSet(p0);
+          return getVideoInfo(0); // Loop if less than 15s of video remaining
+        }
         skipBytes -= 32;
       }
     }
@@ -1261,6 +1275,12 @@ int getTSVVideoInfo(int startTimeOffsetS) {
 
   uint32_t frameSizeBytes = (VIDEO_W * VIDEO_H * 2) + (1024 * 2); // video + audio bytes per frame
   uint32_t totalFrames = infile.fileSize() / frameSizeBytes;
+
+  unsigned int timeOffset = startTimeOffsetS % (totalFrames / frameRate);
+
+  if(totalFrames / frameRate - timeOffset < 15) {
+    return getTSVVideoInfo(0); // Loop if less than 15s of video remaining
+  }
 
   int framesToSkip = startTimeOffsetS * frameRate;
   framesToSkip = framesToSkip % totalFrames;

--- a/SD_AVI.ino
+++ b/SD_AVI.ino
@@ -45,10 +45,12 @@ uint32_t mp4moovSize = 0;
 uint8_t trafBuf1[1024];
 uint8_t trafBuf0[1024];
 uint8_t h264Buf[12288];
-uint8_t flacBuf[8192];
+uint8_t flacBuf[4096];
+uint8_t flacBuf2[4096];
 uint16_t h264SampleOffsets[256];
 uint16_t flacSampleOffsets[256];
 int h264DefaultSampleSize = 0;
+int flacBuf2Len = 0;
 int flacDefaultSampleSize = 0;
 
 int trafOffset;
@@ -354,7 +356,9 @@ int loadFLACDataChunk() {
   int32_t sampleBuf[512];
   uint32_t sampleBufSize = 512;
 
-  if(currentFLACDataChunk >= numFLACDataChunks) return 1;
+  if(currentFLACDataChunk >= numFLACDataChunks) {
+    return 1;
+  }
 
   if(!mutex_try_enter(&flacLoadMtx, NULL)) return 0;
 
@@ -372,7 +376,7 @@ int loadFLACDataChunk() {
 
   uint64_t t1 = micros();
 
-  dbgPrint("(core1) flac chunk decode in "+String((int)(t1-t0)));
+  dbgPrint("(core1) flac chunk decode in "+String((int)(t1-t0)) + +", level: "+String(getAudioSampleCount()));
 
  if(getAudioSampleCount() < 16) {
    totalAudioBufferDrops++;
@@ -516,10 +520,15 @@ int loadMP4TrackFragment(int writeH264TrafInfo = 1) {
         if(tfhdFlags & 1) { /* base-data-offset */ }
         if(tfhdFlags & 2) { /* SDI */ }
 
-        if(tfhdFlags & 8) {
+        if((tfhdFlags & 8)) {
           /* default sample duration */
           sampleDefaultDuration = getIntLE(trafBuf+trafBufStart+28);
-          targetFrameTime = 1000000 / (MP4Timescale / sampleDefaultDuration);
+          if(sampleDefaultDuration != 0) {
+            targetFrameTime = 1000000 / (MP4Timescale / sampleDefaultDuration);
+            dbgPrint("targetFrameTime set to "+String((int)targetFrameTime));
+            dbgPrint("MP4 timescale: "+String(MP4Timescale));
+            dbgPrint("sampleDefaultDuration: "+String(sampleDefaultDuration));
+          }
         }
         
         if(tfhdFlags & 16) { /* default sample size */ }
@@ -622,11 +631,38 @@ void loadNextTraf() {
       
       if(getFLACReady()) {
         dbgPrint("Flushing FLAC samples...");
-        while(!loadFLACDataChunk()) {}
+        infile.seekSet(getReadOffset());
+
+        int writeOffset = 0;
+        int size = trafDefaultSampleSize;
+        for(int i = 0; i < getTrunSampleCount(); i++) {
+          if(flacDefaultSampleSize) {
+            size = getIntLE(
+              getFLACTrafBuf()
+              + trafBufStart
+              + tfhdBase
+              + trunSamplesStart
+              + sampleSizeOffset
+              + i * trafBytesPerSample
+            );
+          }
+          flacSampleOffsets[i] = writeOffset;
+          writeOffset += size;
+        }
+
+        infile.read(flacBuf2, writeOffset);
+        flacBuf2Len = writeOffset;
+
+        dbgPrint("Flushing FLAC samples for next data...");
+        while(!loadFLACDataChunk()) { yield(); }
         uint64_t t0 = micros();
+
         mutex_enter_blocking(&flacLoadMtx);
         currentFLACDataChunk = numFLACDataChunks = 0;
-        skipToAndLoadFLACTraf();
+
+        memcpy(flacBuf, flacBuf2, flacBuf2Len);
+        loadMP4FLACData();
+
         mutex_exit(&flacLoadMtx);
         uint64_t t1 = micros();
         dbgPrint("FLAC skip+load in "+String((int)(t1-t0))+" us");
@@ -640,10 +676,15 @@ void loadNextTraf() {
         return;
       }
 
+      dbgPrint("Getting next toplevel box...");
+
       getMP4NextTopLevel();
+
+      dbgPrint("Skipping MDAT...");
       
       skipIfMdat();
     }
+    //dbgPrint("Tracks loaded!");
 }
 
 void loadH264Samples() {
@@ -736,6 +777,7 @@ void getFLACSample(uint8_t* sampleBuf, int s, uint32_t* size) {
   } else {
     *size = trafDefaultSampleSize;
   }
+  dbgPrint("Copying FLAC sample from "+String(flacSampleOffsets[s]));
   memcpy(sampleBuf, flacBuf+flacSampleOffsets[s], *size);
 }
 

--- a/SD_AVI.ino
+++ b/SD_AVI.ino
@@ -45,10 +45,13 @@ uint32_t mp4moovSize = 0;
 uint8_t trafBuf1[1024];
 uint8_t trafBuf0[1024];
 uint8_t h264Buf[12288];
+uint8_t h264LastSampleBuf[8192];
 uint8_t flacBuf[4096];
 uint8_t flacBuf2[4096];
 uint16_t h264SampleOffsets[256];
 uint16_t flacSampleOffsets[256];
+uint16_t flacSampleOffsets2[256];
+int lastH264SampleSize = 0;
 int h264DefaultSampleSize = 0;
 int flacBuf2Len = 0;
 int flacDefaultSampleSize = 0;
@@ -92,6 +95,7 @@ int loadH264Traf = 1;
 int mp4SeekMS = 0;
 int currentFLACDataChunk = 0;
 int numFLACDataChunks = 0;
+int nextFLACTrunSamplesCount = 0;
 
 bool isMdat() { return haveMdat; }
 bool isMoof() { return haveMoof; }
@@ -108,12 +112,15 @@ int getMP4ToplevelError() { return MP4ToplevelError; }
 int getTrafSamplesReady() { return trafSamplesReady; }
 int getTrafTrack() { return trafTrack; }
 int getTrunSampleCount() { return trunNSamples; }
+int getH264LastSampleSize() { return lastH264SampleSize; }
+void setH264LastSampleSize(int size) { lastH264SampleSize = size; } 
 int getH264SampleCount() { return H264NSamples; }
 int getH264TrafCurrentSample() { return H264TrafCurrentSample; }
 int getTimescaleDuration() { return timescaleDuration; }
 uint8_t* getH264TrafBuf() { return trafBuf0; }
 uint8_t* getFLACTrafBuf() { return trafBuf1; }
 uint8_t* getFLACBuf() { return flacBuf; }
+uint8_t* getH264LastSampleBuf() { return h264LastSampleBuf; }
 
 int H264Decoded = 1;
 
@@ -608,6 +615,8 @@ void loadNextTraf() {
 
     loadFLACDataChunk();
 
+    int p0 = infile.position();
+
     if(loadH264Traf) {
       dbgPrint("Loading tracks!");
       loadMP4TrackFragment(1);
@@ -617,6 +626,7 @@ void loadNextTraf() {
       dbgPrint("H264 skip+load in "+String((int)(t1-t0))+" us");
       
       skipToMoof();
+
       getMP4NextTopLevel();
 
       
@@ -625,12 +635,15 @@ void loadNextTraf() {
       // Load FLAC data
       int ft0 = micros();
 
-      int p0 = infile.position();
-
+      p0 = infile.position();
+      loadFLACTraf = 1;
+    }
+    
+    if(loadFLACTraf) {
       loadMP4TrackFragment(0); // Don't overwrite h264 data
       
       if(getFLACReady()) {
-        dbgPrint("Flushing FLAC samples...");
+
         infile.seekSet(getReadOffset());
 
         int writeOffset = 0;
@@ -646,24 +659,32 @@ void loadNextTraf() {
               + i * trafBytesPerSample
             );
           }
-          flacSampleOffsets[i] = writeOffset;
+          flacSampleOffsets2[i] = writeOffset;
           writeOffset += size;
         }
 
-        infile.read(flacBuf2, writeOffset);
-        flacBuf2Len = writeOffset;
+        nextFLACTrunSamplesCount = getTrunSampleCount();
 
-        dbgPrint("Flushing FLAC samples for next data...");
-        while(!loadFLACDataChunk()) { yield(); }
+        infile.read(flacBuf, writeOffset);
         uint64_t t0 = micros();
 
-        mutex_enter_blocking(&flacLoadMtx);
-        currentFLACDataChunk = numFLACDataChunks = 0;
+        dbgPrint("Flushing FLAC samples...");
 
-        memcpy(flacBuf, flacBuf2, flacBuf2Len);
-        loadMP4FLACData();
+        while(!loadFLACDataChunk()) { yield(); }
+        
+        numFLACDataChunks = nextFLACTrunSamplesCount;
+        currentFLACDataChunk = 0;
+
+        mutex_enter_blocking(&flacLoadMtx);
+
+        for(int i =0; i < 256; i++) {
+          flacSampleOffsets[i] = flacSampleOffsets2[i];
+        }
+
+        dbgPrint(String(nextFLACTrunSamplesCount)+" flac chunks");
 
         mutex_exit(&flacLoadMtx);
+
         uint64_t t1 = micros();
         dbgPrint("FLAC skip+load in "+String((int)(t1-t0))+" us");
         FLACUsed();
@@ -683,6 +704,7 @@ void loadNextTraf() {
       dbgPrint("Skipping MDAT...");
       
       skipIfMdat();
+      loadFLACTraf = 0;
     }
     //dbgPrint("Tracks loaded!");
 }
@@ -723,6 +745,14 @@ void getH264Sample(uint8_t* sampleBuf, int s, int* size) {
   }
   dbgPrint("Copying h264 at sample offset "+String(h264SampleOffsets[s])+" and size "+String(*size));
   memcpy(sampleBuf, h264Buf+h264SampleOffsets[s], *size);
+}
+
+void loadLastH264Sample(int s) {
+  getH264Sample(h264LastSampleBuf, s, &lastH264SampleSize);
+}
+
+void pushLastH264Sample(uint8_t* sampleBuf) {
+  memcpy(sampleBuf, h264LastSampleBuf, lastH264SampleSize);
 }
 
 uint8_t* getH264SamplePtr(int s, int* size) {

--- a/TinyCircuits-TinyTVs-Firmware.ino
+++ b/TinyCircuits-TinyTVs-Firmware.ino
@@ -33,7 +33,7 @@
 */
 
 // Uncomment to compile debug version
-#define DEBUGAPP (true)
+//#define DEBUGAPP (true)
 
 // This include order matters
 #include <SPI.h>

--- a/TinyCircuits-TinyTVs-Firmware.ino
+++ b/TinyCircuits-TinyTVs-Firmware.ino
@@ -251,7 +251,9 @@ void loop() {
   if (USBJustConnected() && !live) {
     releaseSdCardForUSBMSC();
     setAudioSampleRate(100);
+    dbgPrint("Saving settings to SD card!");
     saveSettings(); // Save settings to SD card on USB connect
+    dbgPrint("Saved!");
     USBMSCStart();
     for (int i = 0; i < 50; i++) {
       delay(1);
@@ -300,10 +302,31 @@ void loop() {
     }
     //USBMSC ejected, return to video playback:
     clearPowerButtonPressInt();
-    loadSettings(); // Reload settings from SD card in case user changed them
+
     if (inputFlags.settingsChanged) {
       inputFlags.settingsChanged = false;
+      dbgPrint("Overwriting settings to LFS!");
       saveSettingsFlashBuffer();
+      saveSettings();
+      dbgPrint("Overwritten!");
+    } else {
+      dbgPrint("Copying settings to LFS!");
+
+      File32 src;
+      src.open("settings.txt", O_READ);
+
+      File dst = LittleFS.open("settings.txt", "w");
+      uint8_t buf[512];
+      
+      while(src.available()) {
+        size_t read = src.read(buf, 512);
+        dst.write(buf, read);
+      }
+
+      dst.close();
+      src.close();
+
+      dbgPrint("Copied!");
     }
     initVideoPlayback(true);
   }
@@ -729,6 +752,8 @@ bool frameWaitDurationElapsed() {
     if ((int64_t(micros() - framerateHelper) < (targetFrameTime - 5000))) {
       yield();
 #ifndef TinyTVKit
+      // dbgPrint("Loading FLAC chunks inner, framerateHelper: "+String((int)framerateHelper)+", diff: "+String((int)(int64_t(micros() - framerateHelper))));
+      // dbgPrint("targetFrameTime: "+String((int)(targetFrameTime - 5000)));
       loadFLACDataChunk();
 #endif
       return false;
@@ -751,7 +776,11 @@ void setup1() {
 
 void loop1() {
 
+  #if defined(has_USB_MSC) && !defined(TinyTVKit)
+
   MSCloopCore1();
+
+  #endif
   
   if (TVscreenOffMode) {
     return;
@@ -760,7 +789,7 @@ void loop1() {
   //decode JPEG if available
   #ifndef TinyTVKit
   if (!getFilledJPEGBuffer() && !getH264DecodeReady()) {
-    //dbgPrint("No filled JPEG buffer!");
+    //dbgPrint("No filled JPEG buffer or H264 data!");
     return;
   }
   #else

--- a/TinyCircuits-TinyTVs-Firmware.ino
+++ b/TinyCircuits-TinyTVs-Firmware.ino
@@ -86,6 +86,7 @@ char splashVidFileName[20] = "";
 bool splashPlaybackMode = false;
 bool firstFrame = true;
 bool wasInit = false;
+bool lastH264Sample = false;
 
 #ifndef TinyTVKit
 
@@ -650,12 +651,28 @@ void loop() {
 
     if(!getH264DecodeReady() && getH264Ready()) {
         
-      if(getH264TrafCurrentSample() < getH264SampleCount()) {
-        int s_size;
-        getH264Sample(getFreeJPEGBuffer(), getH264TrafCurrentSample(), &s_size);
-        advanceH264TrafCurrentSample();
+      if(getH264TrafCurrentSample() < (getH264SampleCount())) {
+        if(getH264TrafCurrentSample() == (getH264SampleCount()-1)) {
+          dbgPrint("Buffering last H264 sample!!");
+          //while(lastH264Sample) { yield(); }
+          // loadLastH264Sample(getH264TrafCurrentSample());
+          // pushLastH264Sample(getFreeJPEGBuffer());
+          lastH264Sample = true;
+          int bufSize;
+          uint8_t* src = getH264SamplePtr(getH264TrafCurrentSample(), &bufSize);
+          dbgPrint("buffer size: "+String(bufSize));
+          memcpy(getH264LastSampleBuf(), src, bufSize);
+          setH264LastSampleSize(bufSize);
+          H264Used();
+          resetH264Traf();
+        } else {
+          int s_size;
+          getH264Sample(getFreeJPEGBuffer(), getH264TrafCurrentSample(), &s_size);
+          advanceH264TrafCurrentSample();
+          while(!frameWaitDurationElapsed()) { loadFLACDataChunk(); }
+        }
 
-        while(!frameWaitDurationElapsed()) { loadFLACDataChunk(); }
+        //getH264Sample(getFreeJPEGBuffer(), getH264TrafCurrentSample(), &s_size);
         
         dbgPrint("Marking buffer filled!");
         setH264DecodeReady();
@@ -664,7 +681,7 @@ void loop() {
         H264Used();
         resetH264Traf();
       }
-    } else if(!getH264DecodeReady() && (getH264TrafCurrentSample() >= getH264SampleCount())) {
+    } else if(!getH264DecodeReady() && (getH264TrafCurrentSample() >= (getH264SampleCount()))) {
         H264Used();
         resetH264Traf();
     } else {
@@ -832,14 +849,31 @@ void loop1() {
       dbgPrint("Core1 fixing and decoding...");
 
       int bufSize = -1;
-      uint8_t* bufPtr = getH264SamplePtr(getH264TrafCurrentSample() - 1, &bufSize);
+      uint8_t* bufPtr;
 
-      if(bufPtr) fixAVCCStream(bufPtr, bufSize);
+      uint32_t ret_code = H264BSD_ERROR;
+
+      if(lastH264Sample) {
+        dbgPrint("Loading last h264 sample!!!");
+        lastH264Sample = false;
+        bufSize = getH264LastSampleSize();
+        bufPtr = getH264LastSampleBuf();
+        
+        if(bufPtr) fixAVCCStream(bufPtr, bufSize);
+        ret_code = h264bsdDecode(decHd, bufPtr, bufSize, &frame_buffer, (u32*)(&w), (u32*)(&h));
+        setH264DecodeDone();
+      } else {
+        bufPtr = getH264SamplePtr(getH264TrafCurrentSample() - 1, &bufSize);
+          if(bufPtr) fixAVCCStream(bufPtr, bufSize);
+        
+        ret_code = h264bsdDecode(decHd, bufPtr, bufSize, &frame_buffer, (u32*)(&w), (u32*)(&h));
+
+        setH264DecodeDone();
+      }
+
       
-      uint32_t ret_code = h264bsdDecode(decHd, bufPtr, bufSize, &frame_buffer, (u32*)(&w), (u32*)(&h));
 
       int push_ready = false;
-      setH264DecodeDone();
       strncpy(getVolumeString(), "|-------|", 10);
       getVolumeString()[1 + volumeSetting] = '+';
 

--- a/TinyCircuits-TinyTVs-Firmware.ino
+++ b/TinyCircuits-TinyTVs-Firmware.ino
@@ -33,7 +33,7 @@
 */
 
 // Uncomment to compile debug version
-//#define DEBUGAPP (true)
+#define DEBUGAPP (true)
 
 // This include order matters
 #include <SPI.h>
@@ -51,8 +51,8 @@ JPEGDEC jpeg;
 bool streamError = false;
 
 // Select ONE from this list!
-//#include "TinyTV2.h"
-#include "TinyTVMini.h"
+#include "TinyTV2.h"
+//#include "TinyTVMini.h"
 //#include "TinyTVKit.h"
 
 #ifdef ARDUINO_ARCH_RP2040
@@ -203,7 +203,11 @@ void initVideoPlayback(bool loadSettingsFile) {
     }
   }
   if (loadSettingsFile) {
-    loadSettings();
+    if(LittleFS.exists("settings.txt")) {
+      loadSettingsFlashBuffer();
+    } else {
+      loadSettings();
+    }
   }
   randomSeed(micros());
   if (randStartTime) {
@@ -247,6 +251,7 @@ void loop() {
   if (USBJustConnected() && !live) {
     releaseSdCardForUSBMSC();
     setAudioSampleRate(100);
+    saveSettings(); // Save settings to SD card on USB connect
     USBMSCStart();
     for (int i = 0; i < 50; i++) {
       delay(1);
@@ -270,6 +275,17 @@ void loop() {
 #else
     yield();
 #endif
+
+    // Do CDC things anyways
+    uint16_t totalJPEGBytesUnused;
+    if (getFreeJPEGBuffer()) {
+      if (incomingCDCHandler(getFreeJPEGBuffer(), VIDEOBUF_SIZE, &live, &totalJPEGBytesUnused)) {
+        handleUSBMSC(true);
+      }
+    } else {
+      incomingCDCHandler(NULL, 0, &live, &totalJPEGBytesUnused);
+    }
+
     return;
   }
   if (USBMSCJustStopped()) {
@@ -284,9 +300,10 @@ void loop() {
     }
     //USBMSC ejected, return to video playback:
     clearPowerButtonPressInt();
+    loadSettings(); // Reload settings from SD card in case user changed them
     if (inputFlags.settingsChanged) {
       inputFlags.settingsChanged = false;
-      saveSettings();
+      saveSettingsFlashBuffer();
     }
     initVideoPlayback(true);
   }
@@ -341,13 +358,13 @@ void loop() {
   }
 
   if (powerDownTimer && millis() - powerDownTimer > staticTimeMS) {
-    if (settingsNeedSaved) saveSettings();
+    if (settingsNeedSaved) saveSettingsFlashBuffer();
     //off
     powerDownTimer = 0;
     TVscreenOffMode = true;
     TVscreenOffModeStartTime = millis();
     while(!getFreeJPEGBuffer()) {yield();}
-    while(getFilledJPEGBuffer()) {yield();}
+    //while(getFilledJPEGBuffer()) {yield();}
     delay(30);//allow any frames to be displayed
     resetBuffers();
     clearAudioBuffer();
@@ -686,7 +703,7 @@ void loop() {
   if (settingsNeedSaved) {
     if (millis() - settingsNeedSaved > 2000) {
       dbgPrint("Saving settings file");
-      saveSettings();
+      saveSettingsFlashBuffer();
       settingsNeedSaved = 0;
       dbgPrint("Saved settings file");
     }
@@ -733,6 +750,8 @@ void setup1() {
 }
 
 void loop1() {
+
+  MSCloopCore1();
   
   if (TVscreenOffMode) {
     return;

--- a/USB_CDC.h
+++ b/USB_CDC.h
@@ -111,6 +111,7 @@ bool handleCDCcommand(String input) {
 
 void commandSearch(uint16_t jpegBufferSize) {
   while (SerialInterface.available()) {
+    handleUSBMSC(false);
     char c = SerialInterface.read();
     if (!commandStartMS) {
       if (c == '{') {
@@ -126,6 +127,7 @@ void commandSearch(uint16_t jpegBufferSize) {
         if (handleCDCcommand(String(commandBuffer))) {
           // Format error- clear buffer
           while (SerialInterface.available()) {
+            handleUSBMSC(false);
             SerialInterface.read();
           }
         }
@@ -148,8 +150,8 @@ void commandSearch(uint16_t jpegBufferSize) {
 
 bool incomingCDCHandler(uint8_t *jpegBuffer, uint16_t jpegBufferSize, bool *live, uint16_t *totalBytes) {
   //Serial.println("CDC handler!");
-  yield();
-  SerialInterface.flush();
+  // yield();
+  tud_cdc_write_flush(); //SerialInterface.flush();
   if (SerialInterface.available() > 0) {
     liveTimeoutStart = millis();
 

--- a/USB_CDC.h
+++ b/USB_CDC.h
@@ -75,6 +75,8 @@ bool handleCDCcommand(String input) {
       //cdc.println(getKeyValue(val));
     } else if (key == String("SET")) {
       if (setKeyValue(val)) {
+        dbgPrint("Settings changed!");
+        SerialInterface.println("OK: " + val + ":" + getKeyValue(val));
         inputFlags.settingsChanged = true;//.saveSettings();
       }
     } else if (key == String("FORMAT")) {

--- a/USB_MSC.h
+++ b/USB_MSC.h
@@ -57,7 +57,7 @@ uint8_t lbaWriteBuff[512 * 8];
 
 uint32_t sectorLBACount = 1;
 
-const bool secondCoreSD = false;
+const bool secondCoreSD = true;
 
 
 uint32_t lastMSCRead = 0;

--- a/settings.h
+++ b/settings.h
@@ -10,6 +10,8 @@
 //
 //-------------------------------------------------------------------------------
 
+#include <LittleFS.h>
+
 // SETTINGS DEFAULTS
 int channelNumber = 1;
 //int volumeSetting = 3;
@@ -68,6 +70,28 @@ String getKeyValue(String key) {
   return "none";
 }
 
+// extern uint32_t getFreeHeap();
+
+void saveSettingsFlashBuffer() {
+
+  if(!LittleFS.begin()) {
+    dbgPrint("LittleFS.begin() failed!");
+    //return 0;
+  }
+
+  // dbgPrint("free: "+String(getFreeHeap()));
+
+  File flashSettingsFile = LittleFS.open("settingsFlash.txt", "w");
+  //.open("settings.txt", O_WRITE | O_CREAT | O_TRUNC);
+  for (int i = 0; i < sizeof(keyNames) / sizeof(keyNames[0]); i++) {
+    flashSettingsFile.println(String(keyNames[i]) + "=" + getKeyValue(keyNames[i]));
+  }
+  flashSettingsFile.close();
+
+  LittleFS.end();
+  //return 1;
+}
+
 void saveSettings() {
   dbgPrint("saveSettings()");
   File32 settingsFile;
@@ -123,6 +147,38 @@ bool setKeyValue(String line) {
     }
   }
   return false;
+}
+
+void loadSettingsFlashBuffer() {
+  File settingsFileFlash = LittleFS.open("settings.txt", "r");
+  if (!settingsFileFlash) {
+    settingsFileFlash.close();
+    saveSettingsFlashBuffer();
+    return;
+  } else {
+    if (settingsFileFlash.size() == 0) {
+      settingsFileFlash.close();
+      saveSettingsFlashBuffer();
+      return;
+    }
+    //settings file with some data in it.
+    String line = "";
+    while (settingsFileFlash.available()) {
+      char c = settingsFileFlash.read();
+      if ((c != '\n') && (c != '\r')) {
+        line += c;
+      }
+      if ((c == '\n') || (c == '\r') || (settingsFileFlash.available() == 0)) {
+        if (line.length() > 5) {
+          setKeyValue(line);
+        } else {
+          //cdc.print("Empty settings file line?: " + line);
+        }
+        line = "";
+      }
+    }
+    settingsFileFlash.close();
+  }
 }
 
 void loadSettings() {

--- a/settings.h
+++ b/settings.h
@@ -81,7 +81,7 @@ void saveSettingsFlashBuffer() {
 
   // dbgPrint("free: "+String(getFreeHeap()));
 
-  File flashSettingsFile = LittleFS.open("settingsFlash.txt", "w");
+  File flashSettingsFile = LittleFS.open("settings.txt", "w");
   //.open("settings.txt", O_WRITE | O_CREAT | O_TRUNC);
   for (int i = 0; i < sizeof(keyNames) / sizeof(keyNames[0]); i++) {
     flashSettingsFile.println(String(keyNames[i]) + "=" + getKeyValue(keyNames[i]));


### PR DESCRIPTION
This considerably changes behavior on connection to computer, and syncs a copy of the settings file on LittleFS flash storage so we don't have to use the SD card as often.

Fixes a video freeze bug on certain test media and improves audio buffer latency between track fragments.

MSC traffic handling is done more frequently, and hopefully will allow MacOS users to mount the SD card without extra host-side tooling.

Video-seek behavior changed for very short videos; <15s remaining will loop back to the start.